### PR TITLE
Parametrize field boundary line width

### DIFF
--- a/soccer_vision_3d_rviz_markers/conversion.py
+++ b/soccer_vision_3d_rviz_markers/conversion.py
@@ -38,13 +38,13 @@ def ball_to_marker(msg: Ball, diameter: float) -> Marker:
     return marker
 
 
-def field_boundary_to_marker(msg: FieldBoundary) -> Marker:
+def field_boundary_to_marker(msg: FieldBoundary, width: float) -> Marker:
     marker = Marker()
     # FieldBoundary has a header field because it's not part of an array. So, copy the header.
     marker.header = msg.header
     marker.type = Marker.LINE_STRIP
     marker.points = msg.points
-    marker.scale.x = 0.02
+    marker.scale.x = width
     marker.color = ColorRGBA(g=1.0, a=conf_to_alpha(msg.confidence))
     return marker
 

--- a/soccer_vision_3d_rviz_markers/visualizer.py
+++ b/soccer_vision_3d_rviz_markers/visualizer.py
@@ -33,6 +33,7 @@ class SoccerVision3DMarkers(Node):
         # Declare parameters
         self.declare_parameter('ball_diameter', 0.10)
         self.declare_parameter('marking_segment_width', 0.05)
+        self.declare_parameter('field_boundary_line_width', 0.02)
 
         # Create publishers
         self.balls_publisher = self.create_publisher(
@@ -67,7 +68,8 @@ class SoccerVision3DMarkers(Node):
             msg, diameter=self.get_parameter('ball_diameter').value))
 
     def field_boundary_cb(self, msg: FieldBoundary):
-        self.field_boundary_publisher.publish(field_boundary_to_marker(msg))
+        self.field_boundary_publisher.publish(field_boundary_to_marker(
+            msg, width=self.get_parameter('field_boundary_line_width').value))
 
     def goalposts_cb(self, msg: GoalpostArray):
         self.goalposts_publisher.publish(goalpost_array_to_marker_array(msg))

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -57,12 +57,12 @@ def test_ball_to_marker():
     assert marker.color.a == 0.5
 
 
-def test_fieldboundary_to_marker():
+def test_field_boundary_to_marker():
     field_boundary = FieldBoundary()
     field_boundary.points = [
         Point(x=0.1, y=0.2, z=0.3), Point(x=0.4, y=0.5, z=0.6)]
     field_boundary.confidence.confidence = 0.6
-    marker = field_boundary_to_marker(field_boundary)
+    marker = field_boundary_to_marker(field_boundary, width=0.15)
 
     assert marker.type == Marker.LINE_STRIP
     assert marker.action == Marker.MODIFY
@@ -72,7 +72,7 @@ def test_fieldboundary_to_marker():
     assert marker.points[1].x == 0.4
     assert marker.points[1].y == 0.5
     assert marker.points[1].z == 0.6
-    assert marker.scale.x == 0.02
+    assert marker.scale.x == 0.15
     assert marker.color.r == 0.0
     assert marker.color.g == 1.0
     assert marker.color.b == 0.0


### PR DESCRIPTION
This makes the field boundary line width a parameter, since 0.02 can be too small to see on a MSL field, for example.